### PR TITLE
Make default access policy configurable

### DIFF
--- a/src/teamvault/apps/secrets/models.py
+++ b/src/teamvault/apps/secrets/models.py
@@ -15,7 +15,7 @@ from djorm_pgfulltext.models import SearchManager
 from djorm_pgfulltext.fields import VectorField
 from hashids import Hashids
 
-from ...utils import send_mail
+from ...utils import send_mail, pick_constant
 from ..audit.auditlog import log
 from .exceptions import PermissionError
 
@@ -295,7 +295,7 @@ class Secret(HashIDModel):
 
     access_policy = models.PositiveSmallIntegerField(
         choices=ACCESS_POLICY_CHOICES,
-        default=ACCESS_POLICY_REQUEST,
+        default=pick_constant(ACCESS_POLICY_CHOICES, settings.DEFAULT_ACCESS_POLICY),
     )
     allowed_groups = models.ManyToManyField(
         Group,

--- a/src/teamvault/apps/secrets/templates/secrets/secret_addedit.html
+++ b/src/teamvault/apps/secrets/templates/secrets/secret_addedit.html
@@ -110,7 +110,7 @@
 							<div class="col-sm-4">
 								<div id="id_access_policy">
 									<div class="radio">
-										<label for="id_access_policy_1"><input {% if form.access_policy.value|slugify == ACCESS_POLICY_REQUEST %}checked="checked"{% endif %} id="id_access_policy_1" name="access_policy" required="required" title="" value="1" type="radio"> {% trans "default" %}
+										<label for="id_access_policy_1"><input {% if form.access_policy.value|slugify == ACCESS_POLICY_REQUEST %}checked="checked"{% endif %} id="id_access_policy_1" name="access_policy" required="required" title="" value="1" type="radio"> {% trans "request" %}
 										</label>
 									</div>
 									<div class="radio">
@@ -126,7 +126,7 @@
 								</div>
 							</div>
 							<div class="col-sm-6">
-								<p class="form-control-static">{% trans "By <em>default</em>, the secret will show up in search results for all users, but they will have to request access if they're not included in the list of groups and users below.<br><br><em>Everyone</em> will let all users access the secret without the need to grant access below.<br><br><em>Hidden</em> will reveal the existence of the secret and its contents only to users who have been granted access." %}</p>
+								<p class="form-control-static">{% trans "If <em>request</em> is used, the secret will show up in search results for all users, but they will have to request access if they're not included in the list of groups and users below.<br><br><em>Everyone</em> will let all users access the secret without the need to grant access below.<br><br><em>Hidden</em> will reveal the existence of the secret and its contents only to users who have been granted access." %}</p>
 							</div>
 						</div>
 

--- a/src/teamvault/apps/settings/config.py
+++ b/src/teamvault/apps/settings/config.py
@@ -44,6 +44,23 @@ def configure_debugging(config, settings):
         settings.TEMPLATE_DEBUG = False
 
 
+def configure_default_access_policy(config):
+    """
+    Called directly from the Django settings module.
+    """
+    factory_default = "request"
+
+    pol = get_from_config(config, "teamvault", "default_access_policy", factory_default)
+    pol = pol.lower().strip()
+
+    if pol == "everyone":
+        return pol
+    elif pol == "hidden":
+        return pol
+    else:
+        return factory_default
+
+
 def configure_django_secret_key(config):
     """
     Called directly from the Django settings module.
@@ -220,6 +237,9 @@ syslog_facility = local1
 session_cookie_age = 3600
 session_expire_at_browser_close = True
 session_cookie_secure = False
+
+# One of "request", "everyone" or "hidden"
+default_access_policy = request
 
 [django]
 # This key has been generated for you, there is no need to change it

--- a/src/teamvault/settings.py
+++ b/src/teamvault/settings.py
@@ -2,6 +2,7 @@ from os.path import dirname, join, realpath
 
 from .apps.settings.config import (
     configure_database,
+    configure_default_access_policy,
     configure_django_secret_key,
     configure_hashid,
     configure_logging,
@@ -115,6 +116,10 @@ USE_TZ = True
 ### Hashid
 
 HASHID_MIN_LENGTH, HASHID_SALT = configure_hashid(CONFIG)
+
+### Access Policies
+
+DEFAULT_ACCESS_POLICY = configure_default_access_policy(CONFIG)
 
 ### REST Framework
 

--- a/src/teamvault/utils.py
+++ b/src/teamvault/utils.py
@@ -4,6 +4,14 @@ from django.template.loader import get_template, TemplateDoesNotExist
 from django.utils import translation
 
 
+def pick_constant(choices, chosen_description):
+    for constant, description in choices:
+        if description == chosen_description:
+            return constant
+
+    raise KeyError("Can't find {} in {}".format(chosen_description, choices))
+
+
 def send_mail(users_to, subject, template,
               user_from=None, context={}, lang="en",
               attachments=None):


### PR DESCRIPTION
I'm not sure if code quality is up to your standards. Sorry. :(

My goal was not to move the `ACCESS_POLICY_*` constants. Hence, `configure_default_access_policy()` only reads a string and `pick_constant()` returns the appropriate constant.