### PR TITLE
Fix #9 - create possibility for superuser to restore secrets

### DIFF
--- a/src/teamvault/apps/secrets/templates/secrets/secret_detail.html
+++ b/src/teamvault/apps/secrets/templates/secrets/secret_detail.html
@@ -299,7 +299,11 @@ function reveal(password) {
 					<a class="btn btn-default btn-lg" href="{% url "secrets.secret-edit" secret.hashid %}"><i class="fa fa-pencil"></i>&nbsp; {% trans "Edit" %}</a>
 				</div>
 				<div class="btn-group">
+					{% if request.user.is_superuser and secret.status == 3 %}
+					<a class="btn btn-default btn-lg" href="{% url "secrets.secret-restore" secret.hashid %}"><i class="fa fa-trash"></i>&nbsp; {% trans "Restore" %}</a>
+					{% else %}
 					<a class="btn btn-default btn-lg" href="{% url "secrets.secret-delete" secret.hashid %}"><i class="fa fa-trash"></i>&nbsp; {% trans "Delete" %}</a>
+					{% endif %}
 				</div>
 				<div class="btn-group">
 					<button type="button" class="btn btn-default btn-lg" data-toggle="modal" data-target="#modal-share"><i class="fa fa-share"></i>&nbsp; {% trans "Share" %}</button>

--- a/src/teamvault/apps/secrets/templates/secrets/secret_restore.html
+++ b/src/teamvault/apps/secrets/templates/secrets/secret_restore.html
@@ -1,0 +1,35 @@
+{% extends "base_nav.html" %}
+{% load i18n %}
+{% load staticfiles %}
+{% block "title" %}{% trans "Confirm restore" %}{% endblock %}
+{% block "css" %}
+<link href="{% static 'css/secrets.css' %}" rel="stylesheet">
+{% endblock %}
+{% block "content" %}
+<div class="container container-opaque">
+	<div class="row">
+		<div class="col-md-8 col-md-offset-2">
+			<h1>
+				{% blocktrans with name=secret.name content_type=secret.get_content_type_display %}
+				Restore {{ content_type }} '{{ name }}'?
+				{% endblocktrans %}
+			</h1>
+			<hr>
+		</div>
+	</div>
+	<div class="row">
+		<div class="col-md-8 col-md-offset-2">
+			<div class="alert alert-info" role="alert">
+				{% blocktrans %}
+				The password will be restored with all permissions granted to that secret. Please be sure that the secret should be restored and displayed to the users.
+				{% endblocktrans %}
+			</div>
+			<form role="form" method="POST" class="form-horizontal">
+				{% csrf_token %}
+				<a class="btn btn-default btn-lg pull-left" href="{{ secret.get_absolute_url }}"><i class="fa fa-angle-left"></i> &nbsp; {% trans "No, go back" %}</a>
+				<button type="submit" class="btn btn-danger btn-lg pull-right"><i class="fa fa-trash"></i> &nbsp; {% trans "Yes, restore" %}</button>
+			</form>
+		</div>
+	</div>
+</div>
+{% endblock %}

--- a/src/teamvault/apps/secrets/urls.py
+++ b/src/teamvault/apps/secrets/urls.py
@@ -39,6 +39,11 @@ urlpatterns = patterns('',
         name='secrets.secret-delete',
     ),
     url(
+        r'^secrets/(?P<hashid>\w+)/restore$',
+        views.secret_restore,
+        name='secrets.secret-restore',
+    ),
+    url(
         r'^secrets/(?P<hashid>\w+)/download$',
         views.secret_download,
         name='secrets.secret-download',


### PR DESCRIPTION
It should be possible for superusers (admins) to restore secrets. It is based on the delete method but includes a decorator so it's only allowed for superusers.