### PR TITLE
Fix #62 - show credit card secret correctly by using reveal button

### DIFF
--- a/src/teamvault/apps/secrets/templates/secrets/secret_detail.html
+++ b/src/teamvault/apps/secrets/templates/secrets/secret_detail.html
@@ -26,10 +26,9 @@ function getCC() {
 		$('#reveal-button span').text("{% trans "Reveal" %}");
 		$('#reveal-button i').removeClass('fa-shield');
 		$('#reveal-button i').addClass('fa-magic');
-		$('#id_number').val("");
-		$('#id_holder').val("");
-		$('#id_expiration_month').val("");
-		$('#id_expiration_year').val("");
+		$('.jp-card-number').html("•••• •••• •••• ••••");
+		$('.jp-card-name').html("•••••• ••••••");
+		$('.jp-card-expiry').html("••/••••");
 		$('#id_security_code').val("");
 		$('#id_password').val("");
 		$('#copy-security_code').prop("disabled", true);
@@ -41,20 +40,18 @@ function getCC() {
 		$('#reveal-button span').text("{% trans "Hide" %}");
 		$('#reveal-button i').removeClass('fa-magic');
 		$('#reveal-button i').addClass('fa-shield');
-		$('#id_number').val(data['number']);
-		$('#id_holder').val(data['holder']);
-		$('#id_expiration_month').val(data['expiration_month']);
-		$('#id_expiration_year').val(data['expiration_year']);
+		$('.jp-card-number').html(data['number']);
+		$('.jp-card-name').html(data['holder']);
+		$('.jp-card-expiry').html(data['expiration_month'] + "/" + data['expiration_year']);
 		$('#id_security_code').val(data['security_code']);
 		$('#id_password').val(data['password']);
 		$('#copy-security_code').prop("disabled", false);
 		$('#copy-password').prop("disabled", false);
 		reveal_toggled = true;
 	}
-	$('#id_number').change();
-	$('#id_holder').change();
-	$('#id_expiration_month').change();
-	$('#id_expiration_year').change();
+	$('.jp-card-number').change();
+	$('.jp-card-name').change();
+	$('.jp-card-expiry').change();
 	$('#id_security_code').change();
 	$('#id_password').change();
 }


### PR DESCRIPTION
There is an issue by using the `reveal` button to show credit card information. The code modify the content of the `jp-card-wrapper` directly and doesn't recall the `card` javascript class again.