### PR TITLE
Provide customer 404 error page

### DIFF
--- a/src/teamvault/templates/404.html
+++ b/src/teamvault/templates/404.html
@@ -1,0 +1,19 @@
+{% extends "base_nav.html" %}
+{% load staticfiles %}
+{% load i18n %}
+{% block "title" %}{% trans "Page not found" %}{% endblock %}
+{% block "css" %}
+<link href="{% static 'css/secrets.css' %}" rel="stylesheet">
+{% endblock %}
+{% block "nav_search" %}active{% endblock %}
+{% block "content" %}
+<div class="container">
+	<div class="row">
+		<div class="col-md-8 col-md-offset-2">
+			<h1>{% trans "Page not found" %}</h1>
+			<br>
+			<p>Sorry the page you requested couldn't be found. Please check the URL you're using to access the page. If you detect any problem feel free to contact your system administrator.</p>
+		</div>
+	</div>
+</div>
+{% endblock %}

--- a/src/teamvault/templates/base_nav.html
+++ b/src/teamvault/templates/base_nav.html
@@ -14,6 +14,7 @@
 			<a class="navbar-brand" href="{% url 'dashboard' %}">{% trans "TeamVault" %}</a>
 		</div>
 
+		{% if user.is_authenticated %}
 		<div class="collapse navbar-collapse" id="navbar-collapse">
 			<ul class="nav navbar-nav">
 				<li class="{% block "nav_search" %}{% endblock %}">
@@ -60,6 +61,7 @@
 				</li>
 			</ul>
 		</div>
+		{% endif %}
 	</div>
 </nav>
 {% block "content" %}{% endblock %}


### PR DESCRIPTION
If a page isn't found and the user is authenticated the 404 error page is shown with the navigation bar. If the user isn't login the customer 404 page is shown with header but without nav bar.
This would maybe resolve the issue #57